### PR TITLE
fix: Allow user to configure value of endRegex

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export default function whenPlugin (md, options) {
 
   const phrases = options.phrases || [ 'when', 'until' ]
   const startRegex = options.startRegex || '\\(\\($0 ([^)]*?)\\)\\)'
-  const endRegex = options.startRegex || '\\(\\(\\/$0\\)\\)'
+  const endRegex = options.endRegex || '\\(\\(\\/$0\\)\\)'
 
   const whenBlockOpen = options.whenBlockOpen || function (tokens, idx, _options, env, slf) {
     const token = tokens[idx]


### PR DESCRIPTION
Hello, I noticed during usage of the plugin, setting the value of `endRegex` through the options was not effective. This PR changes the variable for the end regex when defined by the user from (previously) the startRegex to endRegex. 